### PR TITLE
HBS-3212: scanner: etf: fields added and remapped

### DIFF
--- a/scanner.etf.qf.json
+++ b/scanner.etf.qf.json
@@ -1054,15 +1054,11 @@
     },
     {
         "name": "k1_form",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "actively_managed",
-        "type": "number"
-    },
-    {
-        "name": "inverse_flag",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "leveraged_flag",
@@ -1070,7 +1066,7 @@
     },
     {
         "name": "leverage_ratio",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "leverage",
@@ -1078,22 +1074,46 @@
     },
     {
         "name": "holds_derivatives_flag",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "currency_hedged_flag",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "ucits_compliant_flag",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "transparent_holding_flag",
-        "type": "number"
+        "type": "text"
     },
     {
         "name": "holdings_region",
         "type": "text"
+    },
+    {
+        "name": "weight_top_10",
+        "type": "final_percent"
+    },
+    {
+        "name": "weight_top_25",
+        "type": "final_percent"
+    },
+    {
+        "name": "weight_top_50",
+        "type": "final_percent"
+    },
+    {
+        "name": "beta_1_year",
+        "type": "number"
+    },
+    {
+        "name": "beta_3_year",
+        "type": "number"
+    },
+    {
+        "name": "beta_5_year",
+        "type": "number"
     }
 ]


### PR DESCRIPTION
The next fields was added:
weight_top_10
weight_top_25
weight_top_50
beta_1_year
beta_3_year
beta_5_year

The next fields was remapped:
k1_form -> text
actively_managed -> text
holds_derivatives_flag -> text
currency_hedged_flag -> text
ucits_compliant_flag -> text
transparent_holding_flag -> text
leverage_ratio -> text

The next field was deleted:
inverse_flag

For more information see the HBS-3212