### PR TITLE
add hotlists

### DIFF
--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -138,7 +138,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -174,7 +174,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -458,7 +458,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -491,7 +491,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -763,7 +763,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -796,7 +796,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -1068,7 +1068,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -1101,7 +1101,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -1373,7 +1373,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -1406,7 +1406,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -1678,7 +1678,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -1711,7 +1711,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -1983,7 +1983,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -2016,7 +2016,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -2288,7 +2288,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -2321,7 +2321,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -2593,7 +2593,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -2626,7 +2626,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -2898,7 +2898,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -2931,7 +2931,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -3203,7 +3203,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -3236,7 +3236,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -3508,7 +3508,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -3541,7 +3541,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -3813,7 +3813,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -3846,7 +3846,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -4118,7 +4118,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -4151,7 +4151,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -4423,7 +4423,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -4456,7 +4456,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -4728,7 +4728,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -4761,7 +4761,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -5033,7 +5033,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -5066,7 +5066,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -5338,7 +5338,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -5371,7 +5371,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -5631,7 +5631,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -5661,7 +5661,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -5921,7 +5921,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -5954,7 +5954,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -6226,7 +6226,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -6259,7 +6259,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -6531,7 +6531,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -6564,7 +6564,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -6836,7 +6836,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -6869,7 +6869,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -7109,7 +7109,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -7134,7 +7134,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -7342,7 +7342,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -7367,7 +7367,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -7595,7 +7595,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -7625,7 +7625,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -7885,7 +7885,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -7918,7 +7918,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -8190,7 +8190,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -8223,7 +8223,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -8495,7 +8495,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -8528,7 +8528,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -8800,7 +8800,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -8833,7 +8833,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -9105,7 +9105,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -9138,7 +9138,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -9410,7 +9410,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -9443,7 +9443,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -9715,7 +9715,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -9748,7 +9748,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -10020,7 +10020,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -10053,7 +10053,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -10325,7 +10325,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -10358,7 +10358,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -10630,7 +10630,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -10663,7 +10663,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -10935,7 +10935,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -10968,7 +10968,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -11240,7 +11240,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -11273,7 +11273,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -11545,7 +11545,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -11578,7 +11578,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -11850,7 +11850,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -11883,7 +11883,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -12155,7 +12155,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -12188,7 +12188,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -12460,7 +12460,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -12493,7 +12493,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -12765,7 +12765,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -12798,7 +12798,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -13070,7 +13070,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -13103,7 +13103,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -13375,7 +13375,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -13408,7 +13408,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -13680,7 +13680,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -13713,7 +13713,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -13985,7 +13985,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -14018,7 +14018,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -14290,7 +14290,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -14323,7 +14323,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -14595,7 +14595,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -14628,7 +14628,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -14900,7 +14900,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -14933,7 +14933,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -15205,7 +15205,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -15238,7 +15238,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -15510,7 +15510,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -15543,7 +15543,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -15815,7 +15815,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -15848,7 +15848,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -16120,7 +16120,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -16153,7 +16153,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -16425,7 +16425,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -16458,7 +16458,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -16730,7 +16730,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -16763,7 +16763,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -17035,7 +17035,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -17068,7 +17068,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -17340,7 +17340,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -17373,7 +17373,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -17645,7 +17645,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -17678,7 +17678,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -17950,7 +17950,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -17983,7 +17983,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -18255,7 +18255,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -18288,7 +18288,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -18560,7 +18560,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -18593,7 +18593,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -18865,7 +18865,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -18898,7 +18898,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -19138,7 +19138,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -19163,7 +19163,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -19403,7 +19403,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -19436,7 +19436,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -19708,7 +19708,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -19741,7 +19741,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -20013,7 +20013,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -20046,7 +20046,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -20318,7 +20318,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -20351,7 +20351,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -20623,7 +20623,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -20656,7 +20656,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -20928,7 +20928,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -20961,7 +20961,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -21233,7 +21233,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -21266,7 +21266,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -21538,7 +21538,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -21571,7 +21571,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -21843,7 +21843,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -21876,7 +21876,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -22148,7 +22148,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -22181,7 +22181,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -22453,7 +22453,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -22486,7 +22486,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -22758,7 +22758,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -22791,7 +22791,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -23063,7 +23063,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -23096,7 +23096,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -23368,7 +23368,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -23401,7 +23401,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -23673,7 +23673,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -23706,7 +23706,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -23978,7 +23978,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -24011,7 +24011,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -24251,7 +24251,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -24276,7 +24276,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -24516,7 +24516,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -24549,7 +24549,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -24821,7 +24821,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -24854,7 +24854,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -25126,7 +25126,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -25159,7 +25159,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -25431,7 +25431,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -25464,7 +25464,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -25736,7 +25736,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -25769,7 +25769,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -26041,7 +26041,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -26074,7 +26074,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -26346,7 +26346,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -26379,7 +26379,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -26651,7 +26651,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -26684,7 +26684,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0
@@ -26956,7 +26956,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: desc
   range:
   - 0
@@ -26989,7 +26989,7 @@ presets:
   - change_from_open
   - volume
   sort:
-    sortBy: range
+    sortBy: change_from_open
     sortOrder: asc
   range:
   - 0

--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -1,0 +1,27138 @@
+---
+cache_policy: private, max-age=10
+presets:
+- name: US_volume_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_change_losers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_range_losers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_gap_gainers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: US_gap_losers
+  filter:
+  - left: exchange
+    operation: in_range
+    right:
+    - AMEX
+    - NASDAQ
+    - NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: AMEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: AMEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NASDAQ_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NASDAQ
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: NYSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NYSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: OTC_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OTC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - america
+- name: TSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: NAG_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NAG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - japan
+- name: TSX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.8
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: TSXV_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TSXV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: CSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: NEO_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.05
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - canada
+- name: SSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: SZSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SZSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - china
+- name: BCS_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCS_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - chile
+- name: BCBA_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: BCBA_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BCBA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - argentina
+- name: ASX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: ASX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ASX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.15
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - australia
+- name: BAHRAIN_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: BAHRAIN_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BAHRAIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - bahrain
+- name: EURONEXTBRU_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: EURONEXTBRU_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTBRU
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - belgium
+- name: BMFBOVESPA_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BMFBOVESPA_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMFBOVESPA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: 
+    - common
+    - preferred
+  - left: type
+    operation: equal
+    right: stock
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - brazil
+- name: BVC_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: BVC_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVC
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - colombia
+- name: CSECY_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: CSECY_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSECY
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 100000
+  - left: volume
+    operation: greater
+    right: 50
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - cyprus
+- name: OMXCOP_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: OMXCOP_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXCOP
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - denmark
+- name: EGX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: EGX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - egypt
+- name: OMXTSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXTSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXTSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - estonia
+- name: OMXRSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXRSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXRSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - latvia
+- name: OMXVSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXVSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXVSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - lithuania
+- name: OMXICE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXICE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXICE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - iceland
+- name: OMXHEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: OMXHEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - finland
+- name: EURONEXTPAR_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: EURONEXTPAR_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTPAR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - france
+- name: BER_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: BER_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BER
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: DUS_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DUS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 20
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: FWB_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: FWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAM_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: HAN_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HAN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: MUN_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MUN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: SWB_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SWB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: TRADEGATE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TRADEGATE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: XETR_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: XETR
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - germany
+- name: ATHEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: ATHEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ATHEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.9
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - greece
+- name: HKEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: HKEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HKEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hongkong
+- name: BET_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BET_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 200
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - hungary
+- name: BSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: BSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: NSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - india
+- name: IDX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: IDX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: IDX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 50
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - indonesia
+- name: TASE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: TASE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TASE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - israel
+- name: MIL_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: MIL_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MIL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - italy
+- name: NSEKE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: NSEKE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSEKE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 6200
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kenya
+- name: KSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: KSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 5000000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - kuwait
+- name: LUXSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: LUXSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LUXSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - luxembourg
+- name: MYX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: MYX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MYX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - malaysia
+- name: BMV_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: BMV_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BMV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - mexico
+- name: CSEMA_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: CSEMA_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSEMA
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - morocco
+- name: NZX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NZX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NZX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - newzealand
+- name: NSENG_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: NSENG_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NSENG
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - nigeria
+- name: PSX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: PSX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - pakistan
+- name: EURONEXTAMS_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: EURONEXTAMS_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTAMS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - netherlands
+- name: BVL_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: BVL_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - peru
+- name: PSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: PSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: PSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 10
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - philippines
+- name: GPW_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: GPW_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: GPW
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 3000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: NEWCONNECT_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NEWCONNECT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - poland
+- name: EURONEXTLIS_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: EURONEXTLIS_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: EURONEXTLIS
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - portugal
+- name: QSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: QSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: QSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - qatar
+- name: BVB_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: BVB_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVB
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.01
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - romania
+- name: MOEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: MOEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: MOEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - russia
+- name: TADAWUL_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: TADAWUL_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TADAWUL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - ksa
+- name: BELEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: BELEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BELEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - serbia
+- name: SGX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: SGX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SGX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - singapore
+- name: BSSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: BSSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BSSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.001
+    - 10000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - slovakia
+- name: JSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: JSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: JSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 20000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - rsa
+- name: KRX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: KRX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: KRX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - korea
+- name: BME_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: BME_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BME
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - spain
+- name: CSELK_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: CSELK_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: CSELK
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - srilanka
+- name: NGM_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: NGM_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: NGM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.02
+    - 500000
+  - left: volume
+    operation: greater
+    right: 1
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: OMXSTO_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OMXSTO
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - sweden
+- name: BX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: BX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 100
+    - 100000
+  - left: volume
+    operation: greater
+    right: 0
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: SIX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SIX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - switzerland
+- name: TPEX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TPEX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TPEX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 150000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: TWSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: TWSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - taiwan
+- name: SET_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: SET_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: SET
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - thailand
+- name: BVMT_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BVMT_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVMT
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1.4
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - tunisia
+- name: BIST_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: BIST_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BIST
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - turkey
+- name: ADX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: ADX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: ADX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.3
+    - 100000
+  - left: volume
+    operation: greater
+    right: 100000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: DFM_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: DFM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.1
+    - 10000
+  - left: volume
+    operation: greater
+    right: 1000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uae
+- name: LSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 10000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: LSIN_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: LSIN
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 2
+    - 10000
+  - left: volume
+    operation: greater
+    right: 2000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - uk
+- name: BVCV_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: BVCV_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: BVCV
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 1
+    - 100000
+  - left: volume
+    operation: greater
+    right: 500
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - venezuela
+- name: HNX_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HNX_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HNX
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: HOSE_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: HOSE
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 500
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: UPCOM_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: UPCOM
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 700
+    - 10000000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - vietnam
+- name: OSL_volume_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - volume
+  - volume
+  sort:
+    sortBy: volume
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_change_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_change_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - change
+  - volume
+  sort:
+    sortBy: change
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_range_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_range_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  columns:
+  - range
+  - volume
+  sort:
+    sortBy: range
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up
+    operation: nempty
+  columns:
+  - gap_up
+  - volume
+  sort:
+    sortBy: gap_up
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_percent_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down
+    operation: nempty
+  columns:
+  - gap_down
+  - volume
+  sort:
+    sortBy: gap_down
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_gap_gainers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_up_abs
+    operation: nempty
+  columns:
+  - gap_up_abs
+  - volume
+  sort:
+    sortBy: gap_up_abs
+    sortOrder: desc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway
+- name: OSL_gap_losers
+  filter:
+  - left: exchange
+    operation: equal
+    right: OSL
+  - left: active_symbol
+    operation: equal
+    right: true
+  - left: typespecs
+    operation: has
+    right: common
+  - left: type
+    operation: equal
+    right: stock
+  - left: close
+    operation: in_range
+    right:
+    - 0.5
+    - 10000
+  - left: volume
+    operation: greater
+    right: 5000
+  - left: gap_down_abs
+    operation: nempty
+  columns:
+  - gap_down_abs
+  - volume
+  sort:
+    sortBy: gap_down_abs
+    sortOrder: asc
+  range:
+  - 0
+  - 20
+  markets: 
+  - norway

--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -1,5 +1,5 @@
 ---
-cache_policy: private, max-age=10
+cache_control: private, max-age=10
 presets:
 - name: US_volume_gainers
   filter:
@@ -135,7 +135,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -171,7 +171,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -455,7 +455,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -488,7 +488,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -760,7 +760,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -793,7 +793,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1065,7 +1065,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1098,7 +1098,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1370,7 +1370,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1403,7 +1403,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1675,7 +1675,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1708,7 +1708,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -1980,7 +1980,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2013,7 +2013,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2285,7 +2285,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2318,7 +2318,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2590,7 +2590,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2623,7 +2623,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2895,7 +2895,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -2928,7 +2928,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3200,7 +3200,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3233,7 +3233,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3505,7 +3505,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3538,7 +3538,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3810,7 +3810,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -3843,7 +3843,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4115,7 +4115,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4148,7 +4148,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4420,7 +4420,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4453,7 +4453,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4725,7 +4725,7 @@ presets:
     operation: greater
     right: 2000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -4758,7 +4758,7 @@ presets:
     operation: greater
     right: 2000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5030,7 +5030,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5063,7 +5063,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5335,7 +5335,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5368,7 +5368,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5628,7 +5628,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5658,7 +5658,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5918,7 +5918,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -5951,7 +5951,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6223,7 +6223,7 @@ presets:
     operation: greater
     right: 50
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6256,7 +6256,7 @@ presets:
     operation: greater
     right: 50
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6528,7 +6528,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6561,7 +6561,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6833,7 +6833,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -6866,7 +6866,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7106,7 +7106,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7131,7 +7131,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7339,7 +7339,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7364,7 +7364,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7592,7 +7592,7 @@ presets:
     - 0.1
     - 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7622,7 +7622,7 @@ presets:
     - 0.1
     - 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7882,7 +7882,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -7915,7 +7915,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8187,7 +8187,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8220,7 +8220,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8492,7 +8492,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8525,7 +8525,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8797,7 +8797,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -8830,7 +8830,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9102,7 +9102,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9135,7 +9135,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9407,7 +9407,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9440,7 +9440,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9712,7 +9712,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -9745,7 +9745,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10017,7 +10017,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10050,7 +10050,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10322,7 +10322,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10355,7 +10355,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10627,7 +10627,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10660,7 +10660,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10932,7 +10932,7 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -10965,7 +10965,7 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11237,7 +11237,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11270,7 +11270,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11542,7 +11542,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11575,7 +11575,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11847,7 +11847,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -11880,7 +11880,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12152,7 +12152,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12185,7 +12185,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12457,7 +12457,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12490,7 +12490,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12762,7 +12762,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -12795,7 +12795,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13067,7 +13067,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13100,7 +13100,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13372,7 +13372,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13405,7 +13405,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13677,7 +13677,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13710,7 +13710,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -13982,7 +13982,7 @@ presets:
     operation: greater
     right: 6200
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14015,7 +14015,7 @@ presets:
     operation: greater
     right: 6200
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14287,7 +14287,7 @@ presets:
     operation: greater
     right: 5000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14320,7 +14320,7 @@ presets:
     operation: greater
     right: 5000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14592,7 +14592,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14625,7 +14625,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14897,7 +14897,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -14930,7 +14930,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15202,7 +15202,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15235,7 +15235,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15507,7 +15507,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15540,7 +15540,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15812,7 +15812,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -15845,7 +15845,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16117,7 +16117,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16150,7 +16150,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16422,7 +16422,7 @@ presets:
     operation: greater
     right: 1000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16455,7 +16455,7 @@ presets:
     operation: greater
     right: 1000000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16727,7 +16727,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -16760,7 +16760,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17032,7 +17032,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17065,7 +17065,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17337,7 +17337,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17370,7 +17370,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17642,7 +17642,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17675,7 +17675,7 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17947,7 +17947,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -17980,7 +17980,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18252,7 +18252,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18285,7 +18285,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18557,7 +18557,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18590,7 +18590,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18862,7 +18862,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -18895,7 +18895,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19135,7 +19135,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19160,7 +19160,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19400,7 +19400,7 @@ presets:
     operation: greater
     right: 500
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19433,7 +19433,7 @@ presets:
     operation: greater
     right: 500
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19705,7 +19705,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -19738,7 +19738,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20010,7 +20010,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20043,7 +20043,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20315,7 +20315,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20348,7 +20348,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20620,7 +20620,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20653,7 +20653,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20925,7 +20925,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -20958,7 +20958,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21230,7 +21230,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21263,7 +21263,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21535,7 +21535,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21568,7 +21568,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21840,7 +21840,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -21873,7 +21873,7 @@ presets:
     operation: greater
     right: 1
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22145,7 +22145,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22178,7 +22178,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22450,7 +22450,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22483,7 +22483,7 @@ presets:
     operation: greater
     right: 0
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22755,7 +22755,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -22788,7 +22788,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23060,7 +23060,7 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23093,7 +23093,7 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23365,7 +23365,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23398,7 +23398,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23670,7 +23670,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23703,7 +23703,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -23975,7 +23975,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24008,7 +24008,7 @@ presets:
     operation: greater
     right: 100
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24248,7 +24248,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24273,7 +24273,7 @@ presets:
     operation: equal
     right: stock
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24513,7 +24513,7 @@ presets:
     operation: greater
     right: 100000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24546,7 +24546,7 @@ presets:
     operation: greater
     right: 100000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24818,7 +24818,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -24851,7 +24851,7 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25123,7 +25123,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25156,7 +25156,7 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25428,7 +25428,7 @@ presets:
     operation: greater
     right: 2000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25461,7 +25461,7 @@ presets:
     operation: greater
     right: 2000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25733,7 +25733,7 @@ presets:
     operation: greater
     right: 500
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -25766,7 +25766,7 @@ presets:
     operation: greater
     right: 500
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26038,7 +26038,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26071,7 +26071,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26343,7 +26343,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26376,7 +26376,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26648,7 +26648,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26681,7 +26681,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26953,7 +26953,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range
@@ -26986,7 +26986,7 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - range
+  - change_from_open
   - volume
   sort:
     sortBy: range

--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -28,7 +28,6 @@ presets:
     right: 10000
   columns:
   - volume
-  - volume
   sort:
     sortBy: volume
     sortOrder: desc
@@ -64,7 +63,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -100,7 +98,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -136,7 +133,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -172,7 +168,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -210,7 +205,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -248,7 +242,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -286,7 +279,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -324,7 +316,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -356,7 +347,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -390,7 +380,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -423,7 +412,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -456,7 +444,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -489,7 +476,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -524,7 +510,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -559,7 +544,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -594,7 +578,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -629,7 +612,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -661,7 +643,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -695,7 +676,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -728,7 +708,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -761,7 +740,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -794,7 +772,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -829,7 +806,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -864,7 +840,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -899,7 +874,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -934,7 +908,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -966,7 +939,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -1000,7 +972,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -1033,7 +1004,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -1066,7 +1036,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -1099,7 +1068,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -1134,7 +1102,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -1169,7 +1136,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -1204,7 +1170,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -1239,7 +1204,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -1271,7 +1235,6 @@ presets:
     operation: greater
     right: 100
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -1305,7 +1268,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -1338,7 +1300,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -1371,7 +1332,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -1404,7 +1364,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -1439,7 +1398,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -1474,7 +1432,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -1509,7 +1466,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -1544,7 +1500,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -1576,7 +1531,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -1610,7 +1564,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -1643,7 +1596,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -1676,7 +1628,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -1709,7 +1660,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -1744,7 +1694,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -1779,7 +1728,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -1814,7 +1762,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -1849,7 +1796,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -1881,7 +1827,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -1915,7 +1860,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -1948,7 +1892,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -1981,7 +1924,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -2014,7 +1956,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -2049,7 +1990,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -2084,7 +2024,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -2119,7 +2058,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -2154,7 +2092,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -2186,7 +2123,6 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -2220,7 +2156,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -2253,7 +2188,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -2286,7 +2220,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -2319,7 +2252,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -2354,7 +2286,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -2389,7 +2320,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -2424,7 +2354,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -2459,7 +2388,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -2491,7 +2419,6 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -2525,7 +2452,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -2558,7 +2484,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -2591,7 +2516,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -2624,7 +2548,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -2659,7 +2582,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -2694,7 +2616,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -2729,7 +2650,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -2764,7 +2684,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -2796,7 +2715,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -2830,7 +2748,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -2863,7 +2780,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -2896,7 +2812,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -2929,7 +2844,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -2964,7 +2878,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -2999,7 +2912,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -3034,7 +2946,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -3069,7 +2980,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -3101,7 +3011,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -3135,7 +3044,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -3168,7 +3076,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -3201,7 +3108,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -3234,7 +3140,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -3269,7 +3174,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -3304,7 +3208,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -3339,7 +3242,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -3374,7 +3276,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -3406,7 +3307,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -3440,7 +3340,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -3473,7 +3372,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -3506,7 +3404,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -3539,7 +3436,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -3574,7 +3470,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -3609,7 +3504,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -3644,7 +3538,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -3679,7 +3572,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -3711,7 +3603,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -3745,7 +3636,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -3778,7 +3668,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -3811,7 +3700,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -3844,7 +3732,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -3879,7 +3766,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -3914,7 +3800,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -3949,7 +3834,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -3984,7 +3868,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -4016,7 +3899,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -4050,7 +3932,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -4083,7 +3964,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -4116,7 +3996,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -4149,7 +4028,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -4184,7 +4062,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -4219,7 +4096,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -4254,7 +4130,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -4289,7 +4164,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -4321,7 +4195,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -4355,7 +4228,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -4388,7 +4260,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -4421,7 +4292,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -4454,7 +4324,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -4489,7 +4358,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -4524,7 +4392,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -4559,7 +4426,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -4594,7 +4460,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -4626,7 +4491,6 @@ presets:
     operation: greater
     right: 2000000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -4660,7 +4524,6 @@ presets:
     right: 2000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -4693,7 +4556,6 @@ presets:
     right: 2000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -4726,7 +4588,6 @@ presets:
     right: 2000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -4759,7 +4620,6 @@ presets:
     right: 2000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -4794,7 +4654,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -4829,7 +4688,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -4864,7 +4722,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -4899,7 +4756,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -4931,7 +4787,6 @@ presets:
     operation: greater
     right: 100
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -4965,7 +4820,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -4998,7 +4852,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -5031,7 +4884,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -5064,7 +4916,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -5099,7 +4950,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -5134,7 +4984,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -5169,7 +5018,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -5204,7 +5052,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -5236,7 +5083,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -5270,7 +5116,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -5303,7 +5148,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -5336,7 +5180,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -5369,7 +5212,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -5404,7 +5246,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -5439,7 +5280,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -5474,7 +5314,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -5509,7 +5348,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -5538,7 +5376,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -5569,7 +5406,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -5599,7 +5435,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -5629,7 +5464,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -5659,7 +5493,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -5691,7 +5524,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -5723,7 +5555,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -5755,7 +5586,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -5787,7 +5617,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -5819,7 +5648,6 @@ presets:
     operation: greater
     right: 100
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -5853,7 +5681,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -5886,7 +5713,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -5919,7 +5745,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -5952,7 +5777,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -5987,7 +5811,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -6022,7 +5845,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -6057,7 +5879,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -6092,7 +5913,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -6124,7 +5944,6 @@ presets:
     operation: greater
     right: 50
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -6158,7 +5977,6 @@ presets:
     right: 50
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -6191,7 +6009,6 @@ presets:
     right: 50
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -6224,7 +6041,6 @@ presets:
     right: 50
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -6257,7 +6073,6 @@ presets:
     right: 50
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -6292,7 +6107,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -6327,7 +6141,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -6362,7 +6175,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -6397,7 +6209,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -6429,7 +6240,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -6463,7 +6273,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -6496,7 +6305,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -6529,7 +6337,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -6562,7 +6369,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -6597,7 +6403,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -6632,7 +6437,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -6667,7 +6471,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -6702,7 +6505,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -6734,7 +6536,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -6768,7 +6569,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -6801,7 +6601,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -6834,7 +6633,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -6867,7 +6665,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -6902,7 +6699,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -6937,7 +6733,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -6972,7 +6767,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -7007,7 +6801,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -7031,7 +6824,6 @@ presets:
     operation: equal
     right: stock
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -7057,7 +6849,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -7082,7 +6873,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -7107,7 +6897,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -7132,7 +6921,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -7159,7 +6947,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -7186,7 +6973,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -7213,7 +6999,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -7240,7 +7025,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -7264,7 +7048,6 @@ presets:
     operation: equal
     right: stock
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -7290,7 +7073,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -7315,7 +7097,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -7340,7 +7121,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -7365,7 +7145,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -7392,7 +7171,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -7419,7 +7197,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -7446,7 +7223,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -7473,7 +7249,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -7502,7 +7277,6 @@ presets:
     - 0.1
     - 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -7533,7 +7307,6 @@ presets:
     - 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -7563,7 +7336,6 @@ presets:
     - 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -7593,7 +7365,6 @@ presets:
     - 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -7623,7 +7394,6 @@ presets:
     - 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -7655,7 +7425,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -7687,7 +7456,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -7719,7 +7487,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -7751,7 +7518,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -7783,7 +7549,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -7817,7 +7582,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -7850,7 +7614,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -7883,7 +7646,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -7916,7 +7678,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -7951,7 +7712,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -7986,7 +7746,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -8021,7 +7780,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -8056,7 +7814,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -8088,7 +7845,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -8122,7 +7878,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -8155,7 +7910,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -8188,7 +7942,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -8221,7 +7974,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -8256,7 +8008,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -8291,7 +8042,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -8326,7 +8076,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -8361,7 +8110,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -8393,7 +8141,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -8427,7 +8174,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -8460,7 +8206,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -8493,7 +8238,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -8526,7 +8270,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -8561,7 +8304,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -8596,7 +8338,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -8631,7 +8372,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -8666,7 +8406,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -8698,7 +8437,6 @@ presets:
     operation: greater
     right: 100
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -8732,7 +8470,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -8765,7 +8502,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -8798,7 +8534,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -8831,7 +8566,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -8866,7 +8600,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -8901,7 +8634,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -8936,7 +8668,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -8971,7 +8702,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -9003,7 +8733,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -9037,7 +8766,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -9070,7 +8798,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -9103,7 +8830,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -9136,7 +8862,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -9171,7 +8896,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -9206,7 +8930,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -9241,7 +8964,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -9276,7 +8998,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -9308,7 +9029,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -9342,7 +9062,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -9375,7 +9094,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -9408,7 +9126,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -9441,7 +9158,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -9476,7 +9192,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -9511,7 +9226,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -9546,7 +9260,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -9581,7 +9294,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -9613,7 +9325,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -9647,7 +9358,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -9680,7 +9390,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -9713,7 +9422,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -9746,7 +9454,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -9781,7 +9488,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -9816,7 +9522,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -9851,7 +9556,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -9886,7 +9590,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -9918,7 +9621,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -9952,7 +9654,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -9985,7 +9686,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -10018,7 +9718,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -10051,7 +9750,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -10086,7 +9784,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -10121,7 +9818,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -10156,7 +9852,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -10191,7 +9886,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -10223,7 +9917,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -10257,7 +9950,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -10290,7 +9982,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -10323,7 +10014,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -10356,7 +10046,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -10391,7 +10080,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -10426,7 +10114,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -10461,7 +10148,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -10496,7 +10182,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -10528,7 +10213,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -10562,7 +10246,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -10595,7 +10278,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -10628,7 +10310,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -10661,7 +10342,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -10696,7 +10376,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -10731,7 +10410,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -10766,7 +10444,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -10801,7 +10478,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -10833,7 +10509,6 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -10867,7 +10542,6 @@ presets:
     right: 150000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -10900,7 +10574,6 @@ presets:
     right: 150000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -10933,7 +10606,6 @@ presets:
     right: 150000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -10966,7 +10638,6 @@ presets:
     right: 150000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -11001,7 +10672,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -11036,7 +10706,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -11071,7 +10740,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -11106,7 +10774,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -11138,7 +10805,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -11172,7 +10838,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -11205,7 +10870,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -11238,7 +10902,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -11271,7 +10934,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -11306,7 +10968,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -11341,7 +11002,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -11376,7 +11036,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -11411,7 +11070,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -11443,7 +11101,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -11477,7 +11134,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -11510,7 +11166,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -11543,7 +11198,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -11576,7 +11230,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -11611,7 +11264,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -11646,7 +11298,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -11681,7 +11332,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -11716,7 +11366,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -11748,7 +11397,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -11782,7 +11430,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -11815,7 +11462,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -11848,7 +11494,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -11881,7 +11526,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -11916,7 +11560,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -11951,7 +11594,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -11986,7 +11628,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -12021,7 +11662,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -12053,7 +11693,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -12087,7 +11726,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -12120,7 +11758,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -12153,7 +11790,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -12186,7 +11822,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -12221,7 +11856,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -12256,7 +11890,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -12291,7 +11924,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -12326,7 +11958,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -12358,7 +11989,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -12392,7 +12022,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -12425,7 +12054,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -12458,7 +12086,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -12491,7 +12118,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -12526,7 +12152,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -12561,7 +12186,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -12596,7 +12220,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -12631,7 +12254,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -12663,7 +12285,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -12697,7 +12318,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -12730,7 +12350,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -12763,7 +12382,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -12796,7 +12414,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -12831,7 +12448,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -12866,7 +12482,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -12901,7 +12516,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -12936,7 +12550,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -12968,7 +12581,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -13002,7 +12614,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -13035,7 +12646,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -13068,7 +12678,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -13101,7 +12710,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -13136,7 +12744,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -13171,7 +12778,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -13206,7 +12812,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -13241,7 +12846,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -13273,7 +12877,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -13307,7 +12910,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -13340,7 +12942,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -13373,7 +12974,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -13406,7 +13006,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -13441,7 +13040,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -13476,7 +13074,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -13511,7 +13108,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -13546,7 +13142,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -13578,7 +13173,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -13612,7 +13206,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -13645,7 +13238,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -13678,7 +13270,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -13711,7 +13302,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -13746,7 +13336,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -13781,7 +13370,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -13816,7 +13404,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -13851,7 +13438,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -13883,7 +13469,6 @@ presets:
     operation: greater
     right: 6200
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -13917,7 +13502,6 @@ presets:
     right: 6200
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -13950,7 +13534,6 @@ presets:
     right: 6200
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -13983,7 +13566,6 @@ presets:
     right: 6200
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -14016,7 +13598,6 @@ presets:
     right: 6200
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -14051,7 +13632,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -14086,7 +13666,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -14121,7 +13700,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -14156,7 +13734,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -14188,7 +13765,6 @@ presets:
     operation: greater
     right: 5000000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -14222,7 +13798,6 @@ presets:
     right: 5000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -14255,7 +13830,6 @@ presets:
     right: 5000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -14288,7 +13862,6 @@ presets:
     right: 5000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -14321,7 +13894,6 @@ presets:
     right: 5000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -14356,7 +13928,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -14391,7 +13962,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -14426,7 +13996,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -14461,7 +14030,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -14493,7 +14061,6 @@ presets:
     operation: greater
     right: 1
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -14527,7 +14094,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -14560,7 +14126,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -14593,7 +14158,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -14626,7 +14190,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -14661,7 +14224,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -14696,7 +14258,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -14731,7 +14292,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -14766,7 +14326,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -14798,7 +14357,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -14832,7 +14390,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -14865,7 +14422,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -14898,7 +14454,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -14931,7 +14486,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -14966,7 +14520,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -15001,7 +14554,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -15036,7 +14588,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -15071,7 +14622,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -15103,7 +14653,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -15137,7 +14686,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -15170,7 +14718,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -15203,7 +14750,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -15236,7 +14782,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -15271,7 +14816,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -15306,7 +14850,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -15341,7 +14884,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -15376,7 +14918,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -15408,7 +14949,6 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -15442,7 +14982,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -15475,7 +15014,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -15508,7 +15046,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -15541,7 +15078,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -15576,7 +15112,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -15611,7 +15146,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -15646,7 +15180,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -15681,7 +15214,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -15713,7 +15245,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -15747,7 +15278,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -15780,7 +15310,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -15813,7 +15342,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -15846,7 +15374,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -15881,7 +15408,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -15916,7 +15442,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -15951,7 +15476,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -15986,7 +15510,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -16018,7 +15541,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -16052,7 +15574,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -16085,7 +15606,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -16118,7 +15638,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -16151,7 +15670,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -16186,7 +15704,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -16221,7 +15738,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -16256,7 +15772,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -16291,7 +15806,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -16323,7 +15837,6 @@ presets:
     operation: greater
     right: 1000000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -16357,7 +15870,6 @@ presets:
     right: 1000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -16390,7 +15902,6 @@ presets:
     right: 1000000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -16423,7 +15934,6 @@ presets:
     right: 1000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -16456,7 +15966,6 @@ presets:
     right: 1000000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -16491,7 +16000,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -16526,7 +16034,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -16561,7 +16068,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -16596,7 +16102,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -16628,7 +16133,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -16662,7 +16166,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -16695,7 +16198,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -16728,7 +16230,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -16761,7 +16262,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -16796,7 +16296,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -16831,7 +16330,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -16866,7 +16364,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -16901,7 +16398,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -16933,7 +16429,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -16967,7 +16462,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -17000,7 +16494,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -17033,7 +16526,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -17066,7 +16558,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -17101,7 +16592,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -17136,7 +16626,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -17171,7 +16660,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -17206,7 +16694,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -17238,7 +16725,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -17272,7 +16758,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -17305,7 +16790,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -17338,7 +16822,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -17371,7 +16854,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -17406,7 +16888,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -17441,7 +16922,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -17476,7 +16956,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -17511,7 +16990,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -17543,7 +17021,6 @@ presets:
     operation: greater
     right: 3000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -17577,7 +17054,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -17610,7 +17086,6 @@ presets:
     right: 3000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -17643,7 +17118,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -17676,7 +17150,6 @@ presets:
     right: 3000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -17711,7 +17184,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -17746,7 +17218,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -17781,7 +17252,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -17816,7 +17286,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -17848,7 +17317,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -17882,7 +17350,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -17915,7 +17382,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -17948,7 +17414,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -17981,7 +17446,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -18016,7 +17480,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -18051,7 +17514,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -18086,7 +17548,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -18121,7 +17582,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -18153,7 +17613,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -18187,7 +17646,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -18220,7 +17678,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -18253,7 +17710,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -18286,7 +17742,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -18321,7 +17776,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -18356,7 +17810,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -18391,7 +17844,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -18426,7 +17878,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -18458,7 +17909,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -18492,7 +17942,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -18525,7 +17974,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -18558,7 +18006,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -18591,7 +18038,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -18626,7 +18072,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -18661,7 +18106,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -18696,7 +18140,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -18731,7 +18174,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -18763,7 +18205,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -18797,7 +18238,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -18830,7 +18270,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -18863,7 +18302,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -18896,7 +18334,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -18931,7 +18368,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -18966,7 +18402,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -19001,7 +18436,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -19036,7 +18470,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -19060,7 +18493,6 @@ presets:
     operation: equal
     right: stock
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -19086,7 +18518,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -19111,7 +18542,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -19136,7 +18566,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -19161,7 +18590,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -19188,7 +18616,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -19215,7 +18642,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -19242,7 +18668,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -19269,7 +18694,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -19301,7 +18725,6 @@ presets:
     operation: greater
     right: 500
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -19335,7 +18758,6 @@ presets:
     right: 500
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -19368,7 +18790,6 @@ presets:
     right: 500
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -19401,7 +18822,6 @@ presets:
     right: 500
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -19434,7 +18854,6 @@ presets:
     right: 500
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -19469,7 +18888,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -19504,7 +18922,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -19539,7 +18956,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -19574,7 +18990,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -19606,7 +19021,6 @@ presets:
     operation: greater
     right: 1
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -19640,7 +19054,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -19673,7 +19086,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -19706,7 +19118,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -19739,7 +19150,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -19774,7 +19184,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -19809,7 +19218,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -19844,7 +19252,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -19879,7 +19286,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -19911,7 +19317,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -19945,7 +19350,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -19978,7 +19382,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -20011,7 +19414,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -20044,7 +19446,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -20079,7 +19480,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -20114,7 +19514,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -20149,7 +19548,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -20184,7 +19582,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -20216,7 +19613,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -20250,7 +19646,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -20283,7 +19678,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -20316,7 +19710,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -20349,7 +19742,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -20384,7 +19776,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -20419,7 +19810,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -20454,7 +19844,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -20489,7 +19878,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -20521,7 +19909,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -20555,7 +19942,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -20588,7 +19974,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -20621,7 +20006,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -20654,7 +20038,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -20689,7 +20072,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -20724,7 +20106,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -20759,7 +20140,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -20794,7 +20174,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -20826,7 +20205,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -20860,7 +20238,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -20893,7 +20270,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -20926,7 +20302,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -20959,7 +20334,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -20994,7 +20368,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -21029,7 +20402,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -21064,7 +20436,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -21099,7 +20470,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -21131,7 +20501,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -21165,7 +20534,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -21198,7 +20566,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -21231,7 +20598,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -21264,7 +20630,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -21299,7 +20664,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -21334,7 +20698,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -21369,7 +20732,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -21404,7 +20766,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -21436,7 +20797,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -21470,7 +20830,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -21503,7 +20862,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -21536,7 +20894,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -21569,7 +20926,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -21604,7 +20960,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -21639,7 +20994,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -21674,7 +21028,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -21709,7 +21062,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -21741,7 +21093,6 @@ presets:
     operation: greater
     right: 1
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -21775,7 +21126,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -21808,7 +21158,6 @@ presets:
     right: 1
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -21841,7 +21190,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -21874,7 +21222,6 @@ presets:
     right: 1
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -21909,7 +21256,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -21944,7 +21290,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -21979,7 +21324,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -22014,7 +21358,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -22046,7 +21389,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -22080,7 +21422,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -22113,7 +21454,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -22146,7 +21486,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -22179,7 +21518,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -22214,7 +21552,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -22249,7 +21586,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -22284,7 +21620,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -22319,7 +21654,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -22351,7 +21685,6 @@ presets:
     operation: greater
     right: 0
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -22385,7 +21718,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -22418,7 +21750,6 @@ presets:
     right: 0
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -22451,7 +21782,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -22484,7 +21814,6 @@ presets:
     right: 0
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -22519,7 +21848,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -22554,7 +21882,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -22589,7 +21916,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -22624,7 +21950,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -22656,7 +21981,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -22690,7 +22014,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -22723,7 +22046,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -22756,7 +22078,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -22789,7 +22110,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -22824,7 +22144,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -22859,7 +22178,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -22894,7 +22212,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -22929,7 +22246,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -22961,7 +22277,6 @@ presets:
     operation: greater
     right: 150000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -22995,7 +22310,6 @@ presets:
     right: 150000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -23028,7 +22342,6 @@ presets:
     right: 150000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -23061,7 +22374,6 @@ presets:
     right: 150000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -23094,7 +22406,6 @@ presets:
     right: 150000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -23129,7 +22440,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -23164,7 +22474,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -23199,7 +22508,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -23234,7 +22542,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -23266,7 +22573,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -23300,7 +22606,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -23333,7 +22638,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -23366,7 +22670,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -23399,7 +22702,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -23434,7 +22736,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -23469,7 +22770,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -23504,7 +22804,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -23539,7 +22838,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -23571,7 +22869,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -23605,7 +22902,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -23638,7 +22934,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -23671,7 +22966,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -23704,7 +22998,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -23739,7 +23032,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -23774,7 +23066,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -23809,7 +23100,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -23844,7 +23134,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -23876,7 +23165,6 @@ presets:
     operation: greater
     right: 100
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -23910,7 +23198,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -23943,7 +23230,6 @@ presets:
     right: 100
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -23976,7 +23262,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -24009,7 +23294,6 @@ presets:
     right: 100
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -24044,7 +23328,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -24079,7 +23362,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -24114,7 +23396,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -24149,7 +23430,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -24173,7 +23453,6 @@ presets:
     operation: equal
     right: stock
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -24199,7 +23478,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -24224,7 +23502,6 @@ presets:
     right: stock
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -24249,7 +23526,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -24274,7 +23550,6 @@ presets:
     right: stock
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -24301,7 +23576,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -24328,7 +23602,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -24355,7 +23628,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -24382,7 +23654,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -24414,7 +23685,6 @@ presets:
     operation: greater
     right: 100000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -24448,7 +23718,6 @@ presets:
     right: 100000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -24481,7 +23750,6 @@ presets:
     right: 100000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -24514,7 +23782,6 @@ presets:
     right: 100000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -24547,7 +23814,6 @@ presets:
     right: 100000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -24582,7 +23848,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -24617,7 +23882,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -24652,7 +23916,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -24687,7 +23950,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -24719,7 +23981,6 @@ presets:
     operation: greater
     right: 1000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -24753,7 +24014,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -24786,7 +24046,6 @@ presets:
     right: 1000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -24819,7 +24078,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -24852,7 +24110,6 @@ presets:
     right: 1000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -24887,7 +24144,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -24922,7 +24178,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -24957,7 +24212,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -24992,7 +24246,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -25024,7 +24277,6 @@ presets:
     operation: greater
     right: 10000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -25058,7 +24310,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -25091,7 +24342,6 @@ presets:
     right: 10000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -25124,7 +24374,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -25157,7 +24406,6 @@ presets:
     right: 10000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -25192,7 +24440,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -25227,7 +24474,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -25262,7 +24508,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -25297,7 +24542,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -25329,7 +24573,6 @@ presets:
     operation: greater
     right: 2000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -25363,7 +24606,6 @@ presets:
     right: 2000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -25396,7 +24638,6 @@ presets:
     right: 2000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -25429,7 +24670,6 @@ presets:
     right: 2000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -25462,7 +24702,6 @@ presets:
     right: 2000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -25497,7 +24736,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -25532,7 +24770,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -25567,7 +24804,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -25602,7 +24838,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -25634,7 +24869,6 @@ presets:
     operation: greater
     right: 500
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -25668,7 +24902,6 @@ presets:
     right: 500
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -25701,7 +24934,6 @@ presets:
     right: 500
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -25734,7 +24966,6 @@ presets:
     right: 500
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -25767,7 +24998,6 @@ presets:
     right: 500
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -25802,7 +25032,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -25837,7 +25066,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -25872,7 +25100,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -25907,7 +25134,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -25939,7 +25165,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -25973,7 +25198,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -26006,7 +25230,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -26039,7 +25262,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -26072,7 +25294,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -26107,7 +25328,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -26142,7 +25362,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -26177,7 +25396,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -26212,7 +25430,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -26244,7 +25461,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -26278,7 +25494,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -26311,7 +25526,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -26344,7 +25558,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -26377,7 +25590,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -26412,7 +25624,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -26447,7 +25658,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -26482,7 +25692,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -26517,7 +25726,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -26549,7 +25757,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -26583,7 +25790,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -26616,7 +25822,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -26649,7 +25854,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -26682,7 +25886,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -26717,7 +25920,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -26752,7 +25954,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -26787,7 +25988,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -26822,7 +26022,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc
@@ -26854,7 +26053,6 @@ presets:
     operation: greater
     right: 5000
   columns:
-  - volume
   - volume
   sort:
     sortBy: volume
@@ -26888,7 +26086,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: desc
@@ -26921,7 +26118,6 @@ presets:
     right: 5000
   columns:
   - change
-  - volume
   sort:
     sortBy: change
     sortOrder: asc
@@ -26954,7 +26150,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: desc
@@ -26987,7 +26182,6 @@ presets:
     right: 5000
   columns:
   - change_from_open
-  - volume
   sort:
     sortBy: change_from_open
     sortOrder: asc
@@ -27022,7 +26216,6 @@ presets:
     operation: nempty
   columns:
   - gap_up
-  - volume
   sort:
     sortBy: gap_up
     sortOrder: desc
@@ -27057,7 +26250,6 @@ presets:
     operation: nempty
   columns:
   - gap_down
-  - volume
   sort:
     sortBy: gap_down
     sortOrder: asc
@@ -27092,7 +26284,6 @@ presets:
     operation: nempty
   columns:
   - gap_up_abs
-  - volume
   sort:
     sortBy: gap_up_abs
     sortOrder: desc
@@ -27127,7 +26318,6 @@ presets:
     operation: nempty
   columns:
   - gap_down_abs
-  - volume
   sort:
     sortBy: gap_down_abs
     sortOrder: asc

--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -1,5 +1,5 @@
 ---
-cache_control: private, max-age=10
+cache_control: public, max-age=10
 presets:
 - name: US_volume_gainers
   filter:

--- a/presets/hotlists.yaml
+++ b/presets/hotlists.yaml
@@ -5217,7 +5217,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5250,7 +5250,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5283,7 +5283,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5316,7 +5316,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5349,7 +5349,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5382,7 +5382,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5417,7 +5417,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5452,7 +5452,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -5487,7 +5487,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTBRU
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8374,7 +8374,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8407,7 +8407,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8440,7 +8440,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8473,7 +8473,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8506,7 +8506,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8539,7 +8539,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8574,7 +8574,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8609,7 +8609,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -8644,7 +8644,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTPAR
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16609,7 +16609,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16642,7 +16642,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16675,7 +16675,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16708,7 +16708,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16741,7 +16741,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16774,7 +16774,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16809,7 +16809,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16844,7 +16844,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -16879,7 +16879,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTAMS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18134,7 +18134,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18167,7 +18167,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18200,7 +18200,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18233,7 +18233,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18266,7 +18266,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18299,7 +18299,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18334,7 +18334,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18369,7 +18369,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true
@@ -18404,7 +18404,7 @@ presets:
   filter:
   - left: exchange
     operation: equal
-    right: EURONEXTLIS
+    right: EURONEXT
   - left: active_symbol
     operation: equal
     right: true


### PR DESCRIPTION
Пресеты для эндпоинта /presets/:name [HBS-3170](https://jira.xtools.tv/browse/HBS-3170)

В виду отсутствия VolumeSymbolsPercentFilter, для некоторых бирж были сделаны следующие изменения, а именно вместо этого фильтра опытным путем подобран VolumeFilter со значениями:

BCBA (argentina) VolumeSymbolsPercentFilter="90" стало VolumeFilter="1000"
BMFBOVESPA (brazil) VolumeSymbolsPercentFilter="90" стало VolumeFilter="1000"
GPW (poland) VolumeSymbolsPercentFilter="70" стало VolumeFilter="3000"
NEWCONNECT (poland) VolumeSymbolsPercentFilter="70" стало VolumeFilter="1000"
SIX (switzerland) VolumeSymbolsPercentFilter="40" стало VolumeFilter="5000"
OMXVSE (lithuania) VolumeSymbolsPercentFilter="90" заменяющий фильтр не нужен