### PR TITLE
Remove filter "left: active_symbol" in global.yaml

### DIFF
--- a/presets/global.yaml
+++ b/presets/global.yaml
@@ -19,9 +19,6 @@ presets:
   - left: is_primary
     operation: equal
     right: true
-  - left: active_symbol
-    operation: equal
-    right: true
   price_conversion:
     to_currency: USD
   sort:
@@ -115,9 +112,6 @@ presets:
     operation: greater
     right: 14000000000
   - left: is_primary
-    operation: equal
-    right: true
-  - left: active_symbol
     operation: equal
     right: true
   sort:


### PR DESCRIPTION
Remove filter 
"  - left: active_symbol
    operation: equal
    right: true" 
in global.yaml for worlds_largest_companies and worlds_non_us_companies presets.